### PR TITLE
Changed grid layout for different breakpoints issue #38

### DIFF
--- a/src/components/Error/ErrorCard.jsx
+++ b/src/components/Error/ErrorCard.jsx
@@ -28,7 +28,7 @@ function ErrorCard({ error }) {
 
   return (
     <div
-      className="py-4 mb-4 col-span-12 xl:col-span-6 px-6 border-l-4 rounded-lg   items-start bg-dark-secondary flex flex-col"
+      className="py-4 mb-4 col-span-12 md:col-span-6 xl:col-span-4 px-6 border-l-4 rounded-lg   items-start bg-dark-secondary flex flex-col"
       style={{
         borderColor: errorTypeColor,
       }}


### PR DESCRIPTION
Changed the grid layout for different breakpoints. 
- 3 columns for large screens
- 2 columns for medium screens
- 1 column for below medium screens 

Large:
![large-screen](https://user-images.githubusercontent.com/45868098/212401357-4087f4c9-5593-4059-a233-99e6dcd44f1f.png)

Medium:
![medium-screen](https://user-images.githubusercontent.com/45868098/212401411-41f78914-aa3e-441d-965f-1c9575524bd6.png)

Small: 
![small-screen](https://user-images.githubusercontent.com/45868098/212401454-51ba069e-3463-4673-86e2-9d210637fb29.png)
