### PR TITLE
Fixed text overflow on ErrorSolutions component

### DIFF
--- a/src/components/Error/ErrorSolutions.jsx
+++ b/src/components/Error/ErrorSolutions.jsx
@@ -13,7 +13,7 @@ function ErrorSolutions({ solutions }) {
   return (
     <ul>
       {solutions.split("<").map((solution, index) => (
-        <li key={index} className="text-sm text-white">
+        <li key={index} className="text-sm text-white break-all">
           {solution}
         </li>
       ))}


### PR DESCRIPTION
I noticed there was a text overflow issue on the ErrorSolutions component. I went ahead and added the tailwind property of _break-all_ to give the parent element a "word-break: break-all" style.

### Before Change

![GHES-Before](https://user-images.githubusercontent.com/8412613/223285644-2e947df2-3b89-481a-bcce-417988a86db2.png)

### After Change

![GHES-After](https://user-images.githubusercontent.com/8412613/223285675-796c4bfd-16c6-4e89-a866-7be180820a1a.png)
