### PR TITLE
chore: move github api from app.jsx to header.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,18 +7,10 @@ import Layout from "./components/Layout/Layout";
 function App() {
   const [search, setSearch] = useState("");
   const [type, setType] = useState("");
-  const [countStar, setCountStar] = useState(0);
-
-  useEffect(() => {
-    fetch("https://api.github.com/repos/devvsakib/github-error-solve")
-      .then((response) => response.json())
-      .then((data) => setCountStar(data.stargazers_count))
-      .catch((error) => console.error("Error fetching GitHub stars:", error));
-  }, []);
-console.log(countStar)
+  
   return (
     <>
-      <Layout stars={countStar}>
+      <Layout>
         <SearchInput search={search} setSearch={setSearch} setType={setType} />
         <Error search={search} type={type} />
       </Layout>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -10,11 +10,19 @@ import { Link } from "react-router-dom";
 
 import { HiMoon, HiSun } from "react-icons/hi";
 import { ThemeContext } from "../../context/ThemeContext";
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect} from "react";
 
-function Header({ countStar, notice }) {
+function Header({notice }) {
   const { theme, toggleTheme } = useContext(ThemeContext);
   const [open, setOpen] = useState(false);
+  const [countStar, setCountStar] = useState(0);
+
+  useEffect(() => {
+    fetch("https://api.github.com/repos/devvsakib/github-error-solve")
+      .then((response) => response.json())
+      .then((data) => setCountStar(data.stargazers_count))
+      .catch((error) => console.error("Error fetching GitHub stars:", error));
+  }, []);
 
   const navLink = [
     {

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -13,7 +13,6 @@ const Layout = ({ stars, children }) => {
         <div className='flex flex-col justify-between min-h-screen'>
             <ThemeProvider>
                 <Header
-                    countStar={stars}
                     notice={"Under Construction"}
                 />
                 <div className='relative'>


### PR DESCRIPTION
fixes #228 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the `Header` component to dynamically display the number of stars from a GitHub repository.
	- Simplified state management within the `Header` by removing prop dependency on the star count.

- **Bug Fixes**
	- Removed unnecessary API calls by eliminating the `countStar` state from the `App` component.

- **Refactor**
	- Streamlined the data flow between components, focusing on the essential props for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->